### PR TITLE
Ajustando a limpeza da memoria

### DIFF
--- a/src/arken/net/httpclient.cpp
+++ b/src/arken/net/httpclient.cpp
@@ -242,7 +242,10 @@ string HttpClient::perform(string method)
   // cleanup curl stuff
   curl_easy_cleanup(curl);
   curl_formfree(formpost);
-  curl_formfree(lastptr);
+
+  if( !m_formdata ) {
+    curl_formfree(lastptr);
+  }
 
   /* Free the list */
   if( list ) {


### PR DESCRIPTION
Fazendo limpar a memoria do lastptr apenas quando não é um formdata; quando é um formdata o curl_formfree(formpost) já efetua a limpeza da mesma e com isso fica duplicado e emite o erro: "double free or corruption (fasttop)"