### PR TITLE
fix: tornar List:each() stateless (corrige ERROR in finalizer: Resource closed)

### DIFF
--- a/src/bindings/arken/base/string.cpp
+++ b/src/bindings/arken/base/string.cpp
@@ -1277,16 +1277,19 @@ arken_string_List_closure( lua_State *L ) {
   int i = lua_upvalueindex(1);
   luaL_checktype(L, i, LUA_TLIGHTUSERDATA);
   auto ba  = static_cast<List *>(lua_touserdata(L, i));
-  const char * result = ba->each();
-  if ( ba->size() > 100000 ) {
-    lua_pushstring(L, "achei!!!!!!!!");
-    lua_error(L);
-    return 0;
+  int pos = lua_tointeger(L, lua_upvalueindex(2));
+  if( pos >= ba->size() ) {
+    lua_pushnil(L);
+    return 1;
   }
+  int len;
+  const char * result = ba->at(pos, &len);
+  lua_pushinteger(L, pos + 1);
+  lua_replace(L, lua_upvalueindex(2));
   if( result == nullptr ) {
     lua_pushnil(L);
   } else {
-    lua_pushstring(L, result);
+    lua_pushlstring(L, result, len);
   }
   return 1;
 }
@@ -1295,7 +1298,8 @@ static int
 arken_string_List_each( lua_State *L ) {
   List * udata  = checkList( L );
   lua_pushlightuserdata(L, udata);
-  lua_pushcclosure(L, arken_string_List_closure, 1);
+  lua_pushinteger(L, 0);
+  lua_pushcclosure(L, arken_string_List_closure, 2);
   return 1;
 }
 


### PR DESCRIPTION
# fix: tornar `List:each()` stateless (corrige `ERROR in finalizer: Resource closed`)

  ## Resumo

  O iterador `:each()` de `arken.string.List` guardava o estado da iteração em um **cursor na própria `List`** (`m_cursor`). Sair do loop com `break`/`return`/`error` deixava esse cursor no meio, causando dois
  problemas:

  1. Reiterar a mesma `List` **continuava de onde parou** em vez de recomeçar.
  2. Ao coletar a `List` com o cursor no meio, o destrutor lançava erro **dentro do finalizer do LuaJIT**:

ERROR in finalizer: Resource closed when using "each" method, try to allocate a variable


  Como o erro acontecia durante o garbage collector (Lua 5.1 / LuaJIT, sem variáveis *to-be-closed*), ele era impresso, engolido e disparado em momento **não-determinístico** — difícil de rastrear até o arquivo
  de origem.

  A correção move o estado da iteração para o **upvalue da closure** (índice por iterador), lendo via `at(pos)`. O cursor da `List` nunca mais é tocado.

  ## Causa raiz

  `src/bindings/arken/base/string.cpp` — closure antigo:

  ```cpp
  auto ba = static_cast<List *>(lua_touserdata(L, lua_upvalueindex(1)));
  const char * result = ba->each();   // avança o m_cursor DA List (estado compartilhado)
```
  E o destrutor que estourava:
```cpp
  // arken_string_List_gc
  bool running = (udata->cursor() > 0 && udata->cursor() < udata->size());
  delete udata;
  if (running) { lua_pushstring(L, "Resource closed ..."); lua_error(L); }
```
  Correção

  src/bindings/arken/base/string.cpp:
```cpp
  static int arken_string_List_closure(lua_State *L) {
    auto ba = static_cast<List *>(lua_touserdata(L, lua_upvalueindex(1)));
    int pos = lua_tointeger(L, lua_upvalueindex(2));
    if (pos >= ba->size()) { lua_pushnil(L); return 1; }
    int len;
    const char * result = ba->at(pos, &len);
    lua_pushinteger(L, pos + 1);
    lua_replace(L, lua_upvalueindex(2));     // índice vive na closure, não na List
    result ? lua_pushlstring(L, result, len) : lua_pushnil(L);
    return 1;
  }

  static int arken_string_List_each(lua_State *L) {
    List * udata = checkList(L);
    lua_pushlightuserdata(L, udata);
    lua_pushinteger(L, 0);                    // índice inicial por iterador
    lua_pushcclosure(L, arken_string_List_closure, 2);
    return 1;
  }
```
  Agora cada for x in list:each() se comporta como ipairs: índice próprio, sair no meio é inofensivo, loops aninhados na mesma List funcionam, e a List é coletada sem cursor pendente.

  Performance

  Sem impacto. A List é string ** m_array, então at(pos) é acesso direto O(1) — igual ao each() antigo. Por iteração há ~2-3 operações de pilha Lua a mais (ler/escrever o índice no upvalue), compensadas por
  lua_pushlstring(result, len) no lugar de lua_pushstring (não precisa mais de strlen). Complexidade total continua O(n).

  Notas

  - arken_string_List_gc mantém o check de cursor como rede de segurança (agora é código morto para o caminho Lua, pois :each() não avança mais o m_cursor).
  - Removido um bloco de debug (if (ba->size() > 100000) error("achei!!!!!!!!")) que quebrava listas com mais de 100k elementos.

  Como reproduzir / validar

  Script teste lua:
```lua
  local str = ""
  for i = 1, 10 do
    str = str .. "item" .. i .. "\n"
  end

  local list = str:trim():split("\n")

  print("size: " .. list:size())

  print("== primeira passada (break no item 8) ==")
  local count = 0
  for item in list:each() do
    count = count + 1
    print(count, item)
    if count == 8 then
      print(">> BREAK")
      break
    end
  end

  print("== segunda passada (percorrendo de novo) ==")
  for item in list:each() do
    print(item)
  end
```
  Antes (com bug)

  == primeira passada (break no item 8) ==
1 item1
2 item2
3 item3
4 item4
5 item5
6 item6
7 item7
8 item8

  == segunda passada (percorrendo de novo) ==
  item9      <- BUG: deveria recomeçar do item1
  item10     <- BUG

  E, em código real saindo do loop por error, ao coletar a List:

  ERROR in finalizer: Resource closed when using "each" method, try to allocate a variable

  Depois (corrigido)

  == primeira passada (break no item 8) ==
1 item1
2 item2
3 item3
4 item4
5 item5
6 item6
7 item7
8 item8

  == segunda passada (percorrendo de novo) ==
  item1      <- OK: cada each() é independente
  item2
  ...
  item10

  Sem nenhum ERROR in finalizer.
